### PR TITLE
No need to use editable mode for redun install in examples

### DIFF
--- a/examples/05_aws_batch/docker/requirements.txt
+++ b/examples/05_aws_batch/docker/requirements.txt
@@ -1,2 +1,2 @@
 awscli
--e redun/
+redun/

--- a/examples/setup_scheduler/docker/requirements.txt
+++ b/examples/setup_scheduler/docker/requirements.txt
@@ -1,2 +1,2 @@
 awscli
--e redun/
+redun/


### PR DESCRIPTION
Addresses #2 

When installing a package in editable mode (`-e`) the top-level script (`redun`) will use `pkg_resources.ContextualVersionConflict` which fails because aiobotocore uses too narrow of a version range (see https://github.com/fsspec/s3fs/issues/357). Non-editable install installs `redun` without the `pkg_resources.ContextualVersionConflict` check and so no error is raised.

It is probably still worth more rigorously fixing the version conflicts by applying one of the mitigations listed in  https://github.com/fsspec/s3fs/issues/357
