### PR TITLE
Tempdir in script

### DIFF
--- a/redun/scripting.py
+++ b/redun/scripting.py
@@ -1,10 +1,7 @@
 import os
-import shutil
 import subprocess
-import tempfile
-from tempfile import mkdtemp
 from textwrap import dedent
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Tuple, Union
 
 from redun.file import File, Staging
 from redun.task import Task, task
@@ -183,7 +180,7 @@ def _script(
     # Use cache=False to force rerunning script_task since it can't react
     # to invalidation of its output.
     return postprocess_script(
-        script_task.options(cache=False, **task_options)(command), outputs, temp_path=temp_path
+        script_task.options(cache=False, **task_options)(command), outputs
     )
 
 

--- a/redun/scripting.py
+++ b/redun/scripting.py
@@ -155,13 +155,12 @@ def script_task(command: str) -> str:
     return command
 
 
-@task(name="script", namespace="redun", version="1", check_valid="shallow")
+@task(name="script", namespace="redun", version="2", check_valid="shallow")
 def _script(
     command: str,
     inputs: Any,
     outputs: Any,
     task_options: dict = {},
-    temp_path: Optional[str] = None,
 ) -> Any:
     """
     Internal task for executing a script.
@@ -188,8 +187,8 @@ def _script(
     )
 
 
-@task(name="postprocess_script", namespace="redun", version="1")
-def postprocess_script(result: Any, outputs: Any, temp_path: Optional[str] = None) -> Any:
+@task(name="postprocess_script", namespace="redun", version="2")
+def postprocess_script(result: Any, outputs: Any) -> Any:
     """
     Postprocess the results of a script task.
     """
@@ -204,9 +203,6 @@ def postprocess_script(result: Any, outputs: Any, temp_path: Optional[str] = Non
             return cls(value.remote.path)
         else:
             return value
-
-    if temp_path:
-        shutil.rmtree(temp_path)
 
     return map_nested_value(get_file, outputs)
 
@@ -223,12 +219,10 @@ def script(
     command_parts = []
 
     # Prepare tempdir if requested.
-    temp_path: Optional[str]
     if tempdir:
-        temp_path = mkdtemp(suffix=".tempdir")
-        command_parts.append('cd "{}"'.format(temp_path))
-    else:
-        temp_path = None
+        command_parts.append('REDUN_TEMPDIR=$(mktemp -d -t ci-XXXXXXXXXX)')
+        command_parts.append("""trap 'rm -rf -- "$REDUN_TEMPDIR"' EXIT""")
+        command_parts.append('cd $REDUN_TEMPDIR')
 
     # Stage inputs.
     command_parts.extend(input.render_stage() for input in iter_nested_value(inputs))
@@ -253,5 +247,5 @@ def script(
 
     input_args = map_nested_value(get_file, inputs)
     return _script(
-        full_command, input_args, outputs, task_options=task_options, temp_path=temp_path
+        full_command, input_args, outputs, task_options=task_options
     )


### PR DESCRIPTION
This is changes how redun scripts create and manage the optional temp dir.

Previously the temp dir was created and later removed by the "host" machine. This led to errors using `tempdir=True` on remote tasks. (Issue: #20)

With this change, the tempdir creation and removal happens within the shell script that redun generates to wrap the user command. This means it all happens in one place, and the error mentioned above is avoided.

Note- I used the shell scripting pattern mentioned in [this stackoverflow](https://stackoverflow.com/a/687052) to schedule the deletion whenever the script exits. I'm not super confident that this is the best way to do the cleanup, but it seems functional and didn't require me to muck about in `get_wrapped_command()`. Happy to update based on feedback or just leave this here as a simple demo.

Cheers!