### PR TITLE
AWS Batch executor enhancements: shared memory requirements, and more faithful local dev experience

### DIFF
--- a/redun/executors/aws_batch.py
+++ b/redun/executors/aws_batch.py
@@ -129,6 +129,7 @@ def get_or_create_job_definition(
     command: List[str] = ["ls"],
     memory: int = 4,
     vcpus: int = 1,
+    shared_memory: Optional[int] = None,
     role: Optional[str] = None,
     aws_region: str = aws_utils.DEFAULT_AWS_REGION,
     privileged: bool = False,
@@ -159,6 +160,8 @@ def get_or_create_job_definition(
         "ulimits": [],
         "privileged": privileged,
     }
+    if shared_memory is not None:
+        container_props['linuxParameters'] = {"sharedMemorySize": int(shared_memory * 1024)}
     existing_job_def = get_job_definition(job_def_name, batch_client=batch_client)
     if existing_job_def:
         existing_container_props = existing_job_def.get("containerProperties", {})
@@ -199,6 +202,7 @@ def batch_submit(
     memory: int = 4,
     vcpus: int = 1,
     gpus: int = 0,
+    shared_memory: Optional[int] = None,
     retries: int = 1,
     role: Optional[str] = None,
     aws_region: str = aws_utils.DEFAULT_AWS_REGION,
@@ -222,7 +226,12 @@ def batch_submit(
     else:
         job_def_name = job_def_name or make_job_def_name(image, job_def_suffix)
         job_def = get_or_create_job_definition(
-            job_def_name, image, role=role, aws_region=aws_region, privileged=privileged
+            job_def_name,
+            image,
+            role=role,
+            aws_region=aws_region,
+            privileged=privileged,
+            shared_memory=shared_memory
         )
 
     # Container overrides for this job.
@@ -272,6 +281,10 @@ def run_docker(
     volumes: Optional[Iterable[Tuple[str, str]]] = None,
     interactive: bool = True,
     cleanup: bool = False,
+    memory: int = 4,
+    vcpus: int = 1,
+    gpus: int = 0,
+    shared_memory: Optional[int] = None
 ) -> str:
     """
     volumes: a list of ('host', 'container') path pairs for volume mouting.
@@ -308,6 +321,13 @@ def run_docker(
         volumes = []
     for host, container in volumes:
         common_args.extend(["-v", f"{host}:{container}"])
+
+    common_args.extend([f'--memory={memory}g', f'--cpus={vcpus}'])
+    if gpus:
+        # We can't easily assign a single gpu so we just make all available if any GPUs are required
+        common_args.extend(['--gpus', 'all'])
+    if shared_memory is not None:
+        common_args.append(f'--shm-size={shared_memory}g')
 
     common_args.append(image)
     common_args.extend(command)
@@ -379,6 +399,7 @@ def get_batch_job_options(job_options: dict) -> dict:
         "vcpus",
         "gpus",
         "memory",
+        "shared_memory",
         "role",
         "retries",
         "privileged",
@@ -394,7 +415,14 @@ def get_docker_job_options(job_options: dict) -> dict:
     """
     Returns Docker-specific job options from general job options.
     """
-    keys = ["volumes", "interactive"]
+    keys = [
+        "vcpus",
+        "memory",
+        "gpus",
+        "shared_memory",
+        "volumes",
+        "interactive"
+    ]
     return {key: job_options[key] for key in keys if key in job_options}
 
 

--- a/redun/executors/aws_batch.py
+++ b/redun/executors/aws_batch.py
@@ -324,7 +324,7 @@ def run_docker(
 
     common_args.extend([f"--memory={memory}g", f"--cpus={vcpus}"])
     if gpus:
-        # We can't easily assign a single gpu so we just make all available if any GPUs are required
+        # We can't easily assign a single gpu so we make all available if any GPUs are required.
         common_args.extend(["--gpus", "all"])
     if shared_memory is not None:
         common_args.append(f"--shm-size={shared_memory}g")

--- a/redun/executors/aws_batch.py
+++ b/redun/executors/aws_batch.py
@@ -161,7 +161,7 @@ def get_or_create_job_definition(
         "privileged": privileged,
     }
     if shared_memory is not None:
-        container_props['linuxParameters'] = {"sharedMemorySize": int(shared_memory * 1024)}
+        container_props["linuxParameters"] = {"sharedMemorySize": int(shared_memory * 1024)}
     existing_job_def = get_job_definition(job_def_name, batch_client=batch_client)
     if existing_job_def:
         existing_container_props = existing_job_def.get("containerProperties", {})
@@ -231,7 +231,7 @@ def batch_submit(
             role=role,
             aws_region=aws_region,
             privileged=privileged,
-            shared_memory=shared_memory
+            shared_memory=shared_memory,
         )
 
     # Container overrides for this job.
@@ -284,7 +284,7 @@ def run_docker(
     memory: int = 4,
     vcpus: int = 1,
     gpus: int = 0,
-    shared_memory: Optional[int] = None
+    shared_memory: Optional[int] = None,
 ) -> str:
     """
     volumes: a list of ('host', 'container') path pairs for volume mouting.
@@ -322,12 +322,12 @@ def run_docker(
     for host, container in volumes:
         common_args.extend(["-v", f"{host}:{container}"])
 
-    common_args.extend([f'--memory={memory}g', f'--cpus={vcpus}'])
+    common_args.extend([f"--memory={memory}g", f"--cpus={vcpus}"])
     if gpus:
         # We can't easily assign a single gpu so we just make all available if any GPUs are required
-        common_args.extend(['--gpus', 'all'])
+        common_args.extend(["--gpus", "all"])
     if shared_memory is not None:
-        common_args.append(f'--shm-size={shared_memory}g')
+        common_args.append(f"--shm-size={shared_memory}g")
 
     common_args.append(image)
     common_args.extend(command)
@@ -415,14 +415,7 @@ def get_docker_job_options(job_options: dict) -> dict:
     """
     Returns Docker-specific job options from general job options.
     """
-    keys = [
-        "vcpus",
-        "memory",
-        "gpus",
-        "shared_memory",
-        "volumes",
-        "interactive"
-    ]
+    keys = ["vcpus", "memory", "gpus", "shared_memory", "volumes", "interactive"]
     return {key: job_options[key] for key in keys if key in job_options}
 
 

--- a/redun/tests/test_aws_batch.py
+++ b/redun/tests/test_aws_batch.py
@@ -746,6 +746,9 @@ def test_executor_docker(
     # Ensure job options were passed correctly.
     assert run_docker_mock.call_args[1] == {
         "image": "my-image",
+        "gpus": 0,
+        "memory": 4,
+        "vcpus": 1,
     }
 
     run_docker_mock.reset_mock()
@@ -764,6 +767,9 @@ def test_executor_docker(
     # Ensure job options were passed correctly.
     assert run_docker_mock.call_args[1] == {
         "image": "my-image",
+        "gpus": 0,
+        "memory": 4,
+        "vcpus": 1,
     }
 
     # Simulate output file created by job.
@@ -948,6 +954,9 @@ def test_interactive(run_docker_mock, iter_local_job_status_mock, get_aws_user_m
     assert run_docker_mock.call_args[1] == {
         "image": "my-image",
         "interactive": True,
+        "gpus": 0,
+        "memory": 4,
+        "vcpus": 1,
     }
 
     # Cleanly stop executor.

--- a/redun/tests/test_functools.py
+++ b/redun/tests/test_functools.py
@@ -78,19 +78,16 @@ def test_seq(scheduler: Scheduler) -> None:
         calls.append(name)
         return name
 
-    assert (
-        scheduler.run(
-            seq(
-                [
-                    subtask(1, 0.2),
-                    subtask(2, 0.1),
-                    subtask(3, 0.01),
-                    subtask(4, 0.01),
-                ]
-            )
+    assert scheduler.run(
+        seq(
+            [
+                subtask(1, 0.2),
+                subtask(2, 0.1),
+                subtask(3, 0.01),
+                subtask(4, 0.01),
+            ]
         )
-        == [1, 2, 3, 4]
-    )
+    ) == [1, 2, 3, 4]
     assert calls == [1, 2, 3, 4]
 
     assert scheduler.run(seq([])) == []

--- a/redun/tests/test_scheduler_subrun.py
+++ b/redun/tests/test_scheduler_subrun.py
@@ -289,7 +289,7 @@ def test_subrun_cached():
     @task(cache=False)
     def foo(x):
         task_calls.append("foo")
-        return x ** 2
+        return x**2
 
     @task()
     def local_main(x):
@@ -317,7 +317,7 @@ def test_subrun_root_task_cached():
     @task(cache=False)
     def foo(x):
         task_calls.append("foo")
-        return x ** 2
+        return x**2
 
     @task(cache=False)
     def local_main(x):
@@ -345,7 +345,7 @@ def test_subrun_root_task_disabled_cached():
     @task(cache=False)
     def foo(x):
         task_calls.append("foo")
-        return x ** 2
+        return x**2
 
     @task(cache=False)
     def local_main(x):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==21.12b0
+black==22.3.0
 flake8
 freezegun
 isort==5.7.0


### PR DESCRIPTION
Greetings @mattrasmus and team!

This PR adds new capabilities to the AWS Batch Executor.

1. Tasks can specify `shared_memory` as a task option. This will set the "Shared memory size" option in the Batch Job Definition. Some background on this- by default, docker containers are run with a very low 64MB shared memory setting (size of `/dev/shm`). Certain resource-heavy tasks require much more shared memory. In my case, it's training deep neural nets using Pytorch. See [here](https://discuss.pytorch.org/t/training-crashes-due-to-insufficient-shared-memory-shm-nn-dataparallel/26396) for background.

2. When running Batch tasks as local docker containers using `debug=True`, task options for compute resource requirements will now be enforced locally. This applies to `vcpus`, `memory`, `gpus`, and `shared_memory`. This is done using the docker flags `--cpus`, `--memory`, `--gpus` and `--shm`. My original goal here was just to make it possible to run in local containers with high shared memory requirements, but effectively this will make batch debug mode that much more faithful to the behavior in Batch.

If this is a change you'd be interested in merging into redun, great! Happy to update the PR in response to feedback.

Cheers!
Dan Spitz