### PR TITLE
Simplify set_arg_defaults.

### DIFF
--- a/redun/scheduler.py
+++ b/redun/scheduler.py
@@ -159,23 +159,9 @@ def set_arg_defaults(task: "Task", args: Tuple, kwargs: dict) -> Tuple[Tuple, di
     """
     Set default arguments from Task signature.
     """
-    # Start with given kwargs.
-    kwargs2 = dict(kwargs)
-
-    sig = task.signature
-    for i, param in enumerate(sig.parameters.values()):
-        if i < len(args):
-            # User already specified this arg in args.
-            continue
-
-        elif param.name in kwargs2:
-            # User already specified this arg in kwargs.
-            continue
-
-        elif param.default is not param.empty:
-            # Default should be used.
-            kwargs2[param.name] = param.default
-    return args, kwargs2
+    bound = task.signature.bind(*args, **kwargs)
+    bound.apply_defaults()
+    return bound.args, bound.kwargs
 
 
 def format_arg(arg_name: str, value: Any, max_length: int = 200) -> str:

--- a/redun/tests/test_scheduler.py
+++ b/redun/tests/test_scheduler.py
@@ -78,6 +78,8 @@ def test_task_args(scheduler: Scheduler) -> None:
 
     assert scheduler.run(workflow()) == "hello world"
 
+
+def test_default_args(scheduler):
     @task()
     def has_default(x="default"):
         return x

--- a/redun/tests/test_scheduler.py
+++ b/redun/tests/test_scheduler.py
@@ -78,6 +78,19 @@ def test_task_args(scheduler: Scheduler) -> None:
 
     assert scheduler.run(workflow()) == "hello world"
 
+    @task()
+    def has_default(x="default"):
+        return x
+
+    assert scheduler.run(has_default()) == "default"
+
+    @task()
+    def kwonly_arg_default(*, x="default"):
+        return x
+
+    assert scheduler.run(kwonly_arg_default()) == "default"
+    assert scheduler.run(kwonly_arg_default(x="custom")) == "custom"
+
 
 def test_call_deep(scheduler: Scheduler) -> None:
     @task()


### PR DESCRIPTION
@mattrasmus This PR uses the [`signature.bind`](https://docs.python.org/3/library/inspect.html#inspect.Signature.bind) method to simplify the logic for applying default kwargs. This is much simpler, and should continue to work on future versions of python, regardless of changes.

## Testing

I added a few test cases to the relevant test in test_scheduler.py. They pass on both the old and new code.