### PR TITLE
Conda executor and initial example

### DIFF
--- a/examples/conda/.redun/redun.ini
+++ b/examples/conda/.redun/redun.ini
@@ -1,0 +1,6 @@
+[executors.conda]
+# Required options.
+type = conda
+
+conda_environment = my_env
+max_workers = 5

--- a/examples/conda/Makefile
+++ b/examples/conda/Makefile
@@ -1,0 +1,17 @@
+install-conda:
+	mkdir -p conda
+	curl -L -o conda/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+	chmod +x conda/miniconda.sh
+	conda/miniconda.sh -b -p conda
+	conda/bin/conda update conda
+	conda/bin/conda init
+
+create-env:
+	conda create -y -n my_env -c conda-forge python=3.7 pip
+
+install-redun:
+	conda run -n my_env pip3 install -e ../../..
+
+teardown:
+	conda env remove -n my_env
+	rm -rf conda

--- a/examples/conda/workflow.py
+++ b/examples/conda/workflow.py
@@ -1,0 +1,39 @@
+import os
+import time
+import threading
+from typing import Dict, List, Tuple
+
+from redun import task
+
+
+@task(executor="conda", conda='my_env')
+def run_in_conda_process(x: int) -> Tuple[int, int, int]:
+    # Return the process id (pid) to prove this task runs in its own process.
+    time.sleep(1)
+    return (os.getpid(), threading.get_ident(), x + 1)
+
+
+@task()
+def regular_task(x):
+    time.sleep(1)
+    return (os.getpid(), threading.get_ident(), x + 1)
+
+
+@task()
+def main(n: int = 5) -> Dict[str, List[Tuple[int, int, int]]]:
+    data = list(range(n))
+
+    # Fanout across many processes.
+    result = [run_in_conda_process(i) for i in data]
+
+    # Fanout over threads.
+    result2 = [regular_task(i) for i in data]
+
+    # Specify executor at call-time.
+    result3 = [regular_task.options(executor="conda")(n + i) for i in data]
+
+    return {
+        "run_in_conda_process": result,
+        "regular_task": result2,
+        "regular_task_options": result3,
+    }

--- a/redun/__init__.py
+++ b/redun/__init__.py
@@ -1,5 +1,6 @@
 from redun.executors.aws_batch import AWSBatchExecutor  # noqa: F401
 from redun.executors.aws_glue import AWSGlueExecutor  # noqa: F401
+from redun.executors.conda import CondaExecutor  # noqa: F401
 from redun.executors.local import LocalExecutor  # noqa: F401
 from redun.file import Dir, File, ShardedS3Dataset  # noqa: F401
 from redun.handle import Handle  # noqa: F401

--- a/redun/executors/conda.py
+++ b/redun/executors/conda.py
@@ -1,0 +1,249 @@
+"""
+Redun Executor class for running tasks and scripts in a local conda environment.
+"""
+import os
+import pickle
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from shlex import quote
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, List, Optional, Tuple
+
+from redun.config import create_config_section
+from redun.executors import aws_utils
+from redun.executors.base import Executor, register_executor
+from redun.scheduler import Job, Scheduler, Traceback
+from redun.scripting import ScriptError, get_task_command
+from redun.utils import get_import_paths, pickle_dump
+
+
+@register_executor("conda")
+class CondaExecutor(Executor):
+    """
+    Executor that runs tasks and scripts in a local conda environment.
+    """
+
+    def __init__(self, name: str, scheduler: Scheduler = None, config=None):
+        super().__init__(name, scheduler=scheduler)
+
+        # Parse config.
+        if not config:
+            config = create_config_section()
+
+        self.max_workers = config.getint("max_workers", 20)
+        self.default_env = config.get("conda_environment")
+
+        self._thread_executor: Optional[ThreadPoolExecutor] = None
+
+    def _start(self) -> None:
+        """
+        Start pool on first Job submission.
+        """
+        if not self._thread_executor:
+            self._thread_executor = ThreadPoolExecutor(max_workers=self.max_workers)
+
+    def stop(self) -> None:
+        """
+        Stop Executor pools.
+        """
+        if self._thread_executor:
+            self._thread_executor.shutdown()
+            self._thread_executor = None
+
+    def _submit(self, job: Job, args: Tuple, kwargs: dict) -> None:
+        # Ensure pool are started.
+        self._start()
+
+        # Run job in a new thread or process.
+        assert self._thread_executor
+        assert job.task
+
+        def on_done(future):
+            success, result = future.result()
+            if success:
+                self.scheduler.done_job(job, result)
+            else:
+                error, traceback = result
+                self.scheduler.reject_job(job, error, traceback)
+
+        self._thread_executor.submit(
+            execute, job, self.get_job_env(job), args, kwargs
+        ).add_done_callback(on_done)
+
+    def submit(self, job: Job, args: Tuple, kwargs: dict) -> None:
+        assert job.task
+        assert not job.task.script
+        self._submit(job, args, kwargs)
+
+    def submit_script(self, job: Job, args: Tuple, kwargs: dict) -> None:
+        assert job.task
+        assert job.task.script
+        self._submit(job, args, kwargs)
+
+    def get_job_env(self, job: Job) -> str:
+        """
+        Return the conda environment name for the given job.
+        """
+        result = job.get_option("conda", self.default_env)
+        if result is None:
+            raise RuntimeError('No conda environment name or default value provided.')
+        return result
+
+def execute(
+    job: Job,
+    env_name: str,
+    args: Tuple = (),
+    kwargs: Dict[str, Any] = None,
+) -> Tuple[bool, Any]:
+    """
+    Run a job in a local conda environment.
+    """
+    assert job.task
+
+    if kwargs is None:
+        kwargs = {}
+    with TemporaryDirectory() as task_files_dir:
+        input_path = os.path.join(task_files_dir, "input")
+        output_path = os.path.join(task_files_dir, "output")
+        error_path = os.path.join(task_files_dir, "error")
+
+        command_path = os.path.join(task_files_dir, "command")
+        command_output_path = os.path.join(task_files_dir, "command_output")
+        command_error_path = os.path.join(task_files_dir, "command_error")
+
+        if job.task.script:
+            # Careful. This will execute the body of the task in the host environment.
+            # The rest of redun all works like this so I'm not changing it here.
+            inner_command = [get_task_command(job.task, args, kwargs)]
+        else:
+            # Serialize arguments to input file.
+            with open(input_path, "wb") as f:
+                pickle_dump([args, kwargs], f)
+            inner_command = get_oneshot_command(job, input_path, output_path, error_path)
+
+        command = wrap_command(
+            inner_command, env_name, command_path, command_output_path, command_error_path
+        )
+        cmd_result = subprocess.run(command, check=False, capture_output=False)
+
+        if not job.task.script:
+            return handle_oneshot_output(output_path, error_path, command_error_path)
+        else:
+            return handle_script_output(
+                cmd_result.returncode, command_output_path, command_error_path
+            )
+
+
+def get_oneshot_command(job: Job, input_path: str, output_path: str, error_path: str) -> List[str]:
+    """
+    Build up a shell command for executing a redun task using `redun oneshot`.
+    """
+    assert job.task
+
+    # Determine additional python import paths.
+    import_args = []
+    base_path = os.getcwd()
+    for abs_path in get_import_paths():
+        # Use relative paths so that they work inside the docker container.
+        rel_path = os.path.relpath(abs_path, base_path)
+        import_args.append("--import-path")
+        import_args.append(rel_path)
+
+    # Build job command.
+    cache_arg = [] if job.get_option("cache", True) else ["--no-cache"]
+    command = (
+        [
+            aws_utils.REDUN_PROG,
+            "--check-version",
+            aws_utils.REDUN_REQUIRED_VERSION,
+            "oneshot",
+            job.task.load_module,
+        ]
+        + import_args
+        + cache_arg
+        + [
+            "--input",
+            input_path,
+            "--output",
+            output_path,
+            "--error",
+            error_path,
+            job.task.fullname,
+        ]
+    )
+    return command
+
+
+def wrap_command(
+    command: List[str],
+    env_name: str,
+    command_path: str,
+    command_output_path: str,
+    command_error_path: str,
+) -> List[str]:
+    """
+    Given a bash command:
+    1. Wrap it in a `conda run` command.
+    2. Write it to a file.
+    3. Generate and return a command to execute the file, teeing stdout and stderr to files.
+    """
+    conda_command = ["conda", "run", "--no-capture-output", "-n", env_name, *command]
+    inner_cmd_str = " ".join(quote(token) for token in conda_command)
+    with open(command_path, "wt") as cmd_f:
+        cmd_f.write(inner_cmd_str)
+
+    wrapped_command = [
+        "bash",
+        "-c",
+        "-o",
+        "pipefail",
+        """
+chmod +x {command_path}
+. {command_path} 2> >(tee {command_error_path} >&2) | tee {command_output_path}
+""".format(
+            command_path=quote(command_path),
+            command_output_path=quote(command_output_path),
+            command_error_path=quote(command_error_path),
+        ),
+    ]
+    return wrapped_command
+
+
+def handle_oneshot_output(
+    output_path: str, error_path: str, command_error_path: str
+) -> Tuple[bool, Any]:
+    """
+    Handle output of a oneshot command.
+    """
+    if os.path.exists(output_path):
+        with open(output_path, "rb") as f:
+            result = pickle.load(f)
+        return True, result
+    elif os.path.exists(error_path):
+        with open(error_path, "rb") as f:
+            error, error_traceback = pickle.load(f)
+        return False, (error, error_traceback)
+    else:
+        # Cover the case where the oneshot command was not entered or it failed to start.
+        # For conda this could happen if the specified environment name doesn't exist.
+        with open(command_error_path, "rb") as f:
+            error = ScriptError(f.read())
+            error_traceback = Traceback.from_error(error)
+        return False, (error, error_traceback)
+
+
+def handle_script_output(
+    return_code: int, command_output_path: str, command_error_path: str
+) -> Tuple[bool, Any]:
+    """
+    Handle output of a script command.
+    """
+    if return_code == 0:
+        with open(command_output_path, "rb") as f:
+            result = f.read()
+        return True, result
+    else:
+        with open(command_error_path, "rb") as f:
+            error = ScriptError(f.read())
+            error_traceback = Traceback.from_error(error)
+        return False, (error, error_traceback)

--- a/redun/executors/conda.py
+++ b/redun/executors/conda.py
@@ -86,8 +86,9 @@ class CondaExecutor(Executor):
         """
         result = job.get_option("conda", self.default_env)
         if result is None:
-            raise RuntimeError('No conda environment name or default value provided.')
+            raise RuntimeError("No conda environment name or default value provided.")
         return result
+
 
 def execute(
     job: Job,


### PR DESCRIPTION
Greetings @mattrasmus and team!

This is a preliminary PR with an executor for running tasks within local conda environments. I'll be curious to hear your feedback on it!

## Overview of function
Similar to the Batch executor in `debug=True` mode, we construct a command to call `redun oneshot` for tasks (or for scripts, we just use redun's existing script preparation). Then we pass that command to `conda run`, conda's non-interactive execution entrypoint. We maintain a pool of thread workers to actually run the commands in a subprocess and post-process the results.

## Some points of discussion
I think it ought to be possible to abstract most of the machinery here into a more generic "local custom shell executor". Then you could support conda, arbitrary local virtual envs, local docker or other containers, etc.

I wasn't able to reuse any existing utility code for constructing the oneshot commands, due to how `redun.executors.aws_batch.submit_task()` is currently factored. However, my implementation is heavily inspired by what the batch executor does. I'd be happy to try refactoring things a bit in the interest of unification.

Have not added tests yet. I assume you don't want to add `conda` as a dependency so I'm planning to mock the actual subprocess calls.

Happy to answer any questions and open to all suggestions.

Cheers!
Dan Spitz