### PR TITLE
Add missing data.tsv and fix cleanup default

### DIFF
--- a/examples/docker/.redun/redun.ini
+++ b/examples/docker/.redun/redun.ini
@@ -1,0 +1,5 @@
+[executors.docker]
+# Required options.
+type = docker
+image = redun_example
+scratch = scratch

--- a/examples/docker/data.tsv
+++ b/examples/docker/data.tsv
@@ -1,0 +1,7 @@
+1	Alice	red
+2	Bob	red
+3	Claire	blue
+4	Dan	green
+5	Eve	green
+6	Frank	red
+7	Gina	green

--- a/redun/executors/docker.py
+++ b/redun/executors/docker.py
@@ -37,7 +37,7 @@ def run_docker(
     image: str,
     volumes: Iterable[Tuple[str, str]] = [],
     interactive: bool = True,
-    cleanup: bool = True,
+    cleanup: bool = False,
     memory: int = 4,
     vcpus: int = 1,
     gpus: int = 0,


### PR DESCRIPTION
Addresses #35 

## Description

- Add two missing files to the docker example: `data.tsv` and `.redun/redun.ini`.
- Changes back the default value for the `cleanup` argument for docker containers.

## Testing

- Reran the docker example to confirm the fix.