### PR TITLE
working on fixing docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 furo
 myst-parser
+pygments
 sphinx

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 furo
 myst-parser
-pygments
+pygments>=2.12.0
 sphinx

--- a/redun/task.py
+++ b/redun/task.py
@@ -787,6 +787,7 @@ def wraps_task(
     the cost of the extra powers we have.
 
     .. code-block:: python
+
         # An example of arguments consumed by the wrapper
         def wrapper_with_args(wrapper_arg: int) -> Callable[[Func], Task[Func]]:
 


### PR DESCRIPTION
Addresses broken docs build: https://github.com/insitro/redun/runs/6774215146?check_suite_focus=true

My guess is that pygments needs to be more explicitly depended upon.