### PR TITLE
Pass self.region to submit_command() from AWSBatchExecutor._submit_single_job()

### DIFF
--- a/redun/executors/aws_batch.py
+++ b/redun/executors/aws_batch.py
@@ -1256,6 +1256,7 @@ class AWSBatchExecutor(Executor):
                 job,
                 command,
                 job_options=task_options,
+                aws_region=self.aws_region,
             )
 
         self.log(


### PR DESCRIPTION
This fixes a bug where, when submitting a script task with the AWSBatchExecutor, the configured region for the executor was being ignored. It was always using the redun default of us-west-2. With this change it uses the configured region of the executor.

Cheers,
Dan Spitz