### PR TITLE
adding graphviz-dev in Dockerfile to install with apt, and pygraphviz …

### DIFF
--- a/examples/docker/docker/Dockerfile
+++ b/examples/docker/docker/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:20.04
 # Install OS-level libraries.
 RUN apt-get update -y && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
     python3 \
-    python3-pip && \
+    python3-pip \
+    graphviz-dev && \
     apt-get clean
 
 WORKDIR /code

--- a/examples/docker/docker/requirements.txt
+++ b/examples/docker/docker/requirements.txt
@@ -1,1 +1,2 @@
+pygraphviz >= 1.9
 redun/


### PR DESCRIPTION
Running on docker executor with minimal example gave error that pygraphviz was not found. 
Added graphviz-dev to Dockerfile (needed dependency) and pygraphviz >=1.9 to requirements.txt within the docker executor example. A lower version of pygraphviz might be fine too, I tested the minimal example with 1.9 and ran into no issues. 
