### PR TITLE
fix pod deletion on job deletion

### DIFF
--- a/redun/executors/k8s_utils.py
+++ b/redun/executors/k8s_utils.py
@@ -248,5 +248,7 @@ def delete_job(k8s_client: K8SClient, name: str, namespace: str) -> Any:
     Deletes an existing k8s job.
     """
     return k8s_client.batch.delete_namespaced_job(
-        name=name, namespace=namespace, body=client.V1DeleteOptions()
+        name=name,
+        namespace=namespace,
+        body=client.V1DeleteOptions(propagation_policy="Background"),
     )


### PR DESCRIPTION
I noticed that pods (which are started by jobs) weren't being cleaned up.  I set a propagation policy of "background" so when the job is deleted, the pods will be deleted asynchronously (it's possible to do foreground, but I figured that would just slow down the redun k8s executor unnecessarily).