### PR TITLE
Remove develop mode for installing redun during docs build

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           cd docs
           pip install -r requirements.txt
-          pip install -e ../
+          pip install ../
           make api html
 
       - name: Checkout gh-pages branch


### PR DESCRIPTION
PR attempting to fix the build: https://github.com/insitro/redun/actions/runs/3843177149/jobs/6554484366