### PR TITLE
Changed cli, file and k8s files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ docs/build/
 redun.db
 dist/
 build/
+.mypy_cache/
+.pytest_cache/

--- a/redun/cli.py
+++ b/redun/cli.py
@@ -1704,6 +1704,9 @@ class RedunClient:
         logger.info(f"redun :: version {redun.__version__}")
         logger.info(f"config dir: {get_config_dir(args.config)}")
 
+        # Setup Scheduler.
+        scheduler = self.get_scheduler(args, migrate_if_local=True)
+
         # Determine executor.
         executor_name = args.executor
         if not executor_name:
@@ -1713,6 +1716,7 @@ class RedunClient:
             executor.name: executor
             for executor in get_executors_from_config(config.get("executors", {}))
         }
+        executors.update(scheduler.executors)
         executor: Optional[Executor] = executors.get(executor_name)
         if not executor:
             raise RedunClientError(f"Unknown Executor {executor_name}.")
@@ -1721,7 +1725,6 @@ class RedunClient:
         remote_run_command = " ".join(quote(arg) for arg in extra_args)
 
         # Setup Scheduler.
-        scheduler = self.get_scheduler(args, migrate_if_local=True)
         executor.set_scheduler(scheduler)
 
         # Parse task options.

--- a/redun/executors/k8s.py
+++ b/redun/executors/k8s.py
@@ -392,6 +392,7 @@ class K8SExecutor(Executor):
         self.default_task_options = {
             "vcpus": config.getint("vcpus", 1),
             "memory": config.getfloat("memory", 4),
+            "gpus": config.getint("gpus", fallback=0),
             "retries": config.getint("retries", 1),
             "service_account_name": config.get("service_account_name", "default"),
             "job_name_prefix": config.get("job_name_prefix", k8s_utils.DEFAULT_JOB_PREFIX),

--- a/redun/file.py
+++ b/redun/file.py
@@ -700,7 +700,7 @@ class GSFileSystem(FsspecFileSystem):
             if not recursive:
                 return f"gsutil cp {quote(src_path)} {quote(dest_path)}"
             else:
-                return f"gsutil cp -r {quote(src_path)} {quote(dest_path)}"
+                return f"gsutil cp -r {quote(src_path)} {quote(dest_path)}/"
         elif recursive:
             raise ValueError("recursive is not supported with stdin or stdout.")
         elif src_path:

--- a/redun/tests/test_file.py
+++ b/redun/tests/test_file.py
@@ -885,7 +885,7 @@ def test_shell_copy_gs() -> None:
 
     assert (
         get_filesystem("gs").shell_copy("gs://bucket/src", "gs://bucket/dest", recursive=True)
-        == "gsutil cp -r gs://bucket/src gs://bucket/dest"
+        == "gsutil cp -r gs://bucket/src gs://bucket/dest/"
     )
     with pytest.raises(ValueError):
         assert get_filesystem("gs").shell_copy("gs://bucket/src", None, recursive=True)

--- a/redun/tests/test_k8s.py
+++ b/redun/tests/test_k8s.py
@@ -343,6 +343,7 @@ def test_executor(
         "secret_name": None,
         "vcpus": 1,
         "memory": 4,
+        "gpus": 0,
         "k8s_labels": {
             "redun_execution_id": "",
             "redun_job_id": job.id,
@@ -377,6 +378,7 @@ def test_executor(
         "secret_name": None,
         "vcpus": 1,
         "memory": 8,
+        "gpus": 0,
         "k8s_labels": {
             "redun_execution_id": "",
             "redun_job_id": job2.id,


### PR DESCRIPTION
This commit adds two features:

* Change in `file.py`
`gsutil` has different behavior when a filename ends with `/` compared to when it doesn't. Described [here](https://cloud.google.com/storage/docs/folders#gsutil). One suggestion is to always end destination URLs with a `/`.

* Change in `cli.py`: 
Currently it is not possible to use custom defined executors in the `redun launch` command. By just moving up the `scheduler = self.get_scheduler(...)` call, it is possible to do so. Includes test.

* Change in `k8s.py`:
Uses 0 gpus as a default task option.