### PR TITLE
ignore artifacts left over by py.test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ docs/build/
 redun.db
 dist/
 build/
+scratch/
+workflow.py


### PR DESCRIPTION
After running py.test, these files are left over in the root directory.

Might want some pytest fixture to delete this at the end, even if tests fail.