### PR TITLE
Specify vcpu and memory as resourceRequirements in AWS Batch executor

### DIFF
--- a/redun/executors/aws_batch.py
+++ b/redun/executors/aws_batch.py
@@ -425,9 +425,20 @@ def batch_submit(
         # Switch units, redun configs are in GB but AWS uses MB.
         memory_mb = int(memory * 1024)
 
-        container_properties.update({"vcpus": vcpus, "memory": memory_mb})
+        container_properties["resourceRequirements"] = [
+            {
+                "type": "VCPU",
+                "value": str(vcpus),
+            },
+            {
+                "type": "MEMORY",
+                "value": str(memory_mb),
+            },
+        ]
         if gpus > 0:
-            container_properties["resourceRequirements"] = [{"type": "GPU", "value": str(gpus)}]
+            container_properties["resourceRequirements"].append(
+                {"type": "GPU", "value": str(gpus)}
+            )
 
     if "containerOverrides" in batch_job_args:
         apply_resources(batch_job_args["containerOverrides"])

--- a/redun/tests/test_aws_batch.py
+++ b/redun/tests/test_aws_batch.py
@@ -484,9 +484,11 @@ def test_job_submit_resources(get_or_create_job_definition_mock, get_aws_client_
         retryStrategy={"attempts": 1},
         containerOverrides={
             "command": ["test_command"],
-            "vcpus": 4,
-            "memory": 8192,
-            "resourceRequirements": [{"type": "GPU", "value": "2"}],
+            "resourceRequirements": [
+                {"type": "VCPU", "value": "4"},
+                {"type": "MEMORY", "value": "8192"},
+                {"type": "GPU", "value": "2"},
+            ],
         },
         propagateTags=True,
         user="user-test",
@@ -529,18 +531,22 @@ def test_job_submit_resources(get_or_create_job_definition_mock, get_aws_client_
                     "targetNodes": "0",
                     "containerOverrides": {
                         "command": ["command_rank_0"],
-                        "vcpus": 4,
-                        "memory": 8192,
-                        "resourceRequirements": [{"type": "GPU", "value": "2"}],
+                        "resourceRequirements": [
+                            {"type": "VCPU", "value": "4"},
+                            {"type": "MEMORY", "value": "8192"},
+                            {"type": "GPU", "value": "2"},
+                        ],
                     },
                 },
                 {
                     "targetNodes": "1:",
                     "containerOverrides": {
                         "command": ["command_rank_1"],
-                        "vcpus": 4,
-                        "memory": 8192,
-                        "resourceRequirements": [{"type": "GPU", "value": "2"}],
+                        "resourceRequirements": [
+                            {"type": "VCPU", "value": "4"},
+                            {"type": "MEMORY", "value": "8192"},
+                            {"type": "GPU", "value": "2"},
+                        ],
                     },
                 },
             ]


### PR DESCRIPTION
When trying to use redun with AWS Batch on Fargate using the existing `AWSBatchExecutor`, we get the following error:
```
botocore.errorfactory.ClientException: An error occurred (ClientException) when calling the SubmitJob operation: vcpus is not applicable for Fargate. Use resource requirements instead.
```
As it turns out, it looks like specifying `vcpu` and `memory` directly on `containerProperties` is now deprecated (see [here for vcpu](https://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerProperties.html#Batch-Type-ContainerProperties-vcpus) and [here for memory](https://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerProperties.html#Batch-Type-ContainerProperties-memory)) in favor of specifying them in the [`resourceRequirements`](https://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerProperties.html#Batch-Type-ContainerProperties-resourceRequirements) array, so that's the update provided here.

This update will allow running on Fargate with the AWSBatchExecutor.