### PR TITLE
Fix context file read from s3

### DIFF
--- a/redun/cli.py
+++ b/redun/cli.py
@@ -1481,7 +1481,7 @@ class RedunClient:
         """
         new_context = {}
         if context_file:
-            with open(context_file, "r") as fp:
+            with BaseFile(context_file).open() as fp:
                 new_context = json.load(fp)
 
         if context_updates:


### PR DESCRIPTION
Addresses #112 

cc @wfondrie 

Use redun's `File` class so that we can support context files from any redun-supported file system.