### PR TITLE
Fix rich escaping for errors

### DIFF
--- a/redun/console/screens.py
+++ b/redun/console/screens.py
@@ -1123,13 +1123,13 @@ class JobScreen(RedunScreen):
             if self.job.status == "FAILED":
                 error_value = self.job.call_node.value.value_parsed
                 error = error_value.error if isinstance(error_value, ErrorValue) else "Unknown"
-                result = Static(f"[bold]Raised:[/] {error}")
+                result = Static(f"[bold]Raised:[/] {rich_escape(str(error))}")
 
                 lines = ["", "[bold]Traceback:[/]"]
                 if isinstance(error_value, ErrorValue) and error_value.traceback:
                     for line in error_value.traceback.format():
-                        lines.append(line.rstrip("\n"))
-                traceback = [Static(rich_escape("\n".join(lines)))]
+                        lines.append(rich_escape(line.rstrip("\n")))
+                traceback = [Static("\n".join(lines))]
             else:
                 result = ValueSpan(
                     self.job.call_node.value,


### PR DESCRIPTION
Fixes #122 

Previously missed escaping errors when displaying `redun console`.

The brackets in `[FileNotFoundError]` from the example were not being escaped before being processed by `rich`.

Here is what the fix looks like. Error is probably displayed and `Traceback` header is bold.

<img width="664" alt="Screenshot 2025-05-28 at 7 39 54 PM" src="https://github.com/user-attachments/assets/060fc12b-dcfe-4133-96e7-979737f04818" />
