### PR TITLE
Added high-level diagrams

### DIFF
--- a/.codeboarding/Data_State_Management.md
+++ b/.codeboarding/Data_State_Management.md
@@ -1,0 +1,209 @@
+```mermaid
+
+graph LR
+
+    redun_value["redun.value"]
+
+    redun_file["redun.file"]
+
+    redun_hashing["redun.hashing"]
+
+    redun_backends_base["redun.backends.base"]
+
+    redun_backends_db["redun.backends.db"]
+
+    redun_backends_value_store["redun.backends.value_store"]
+
+    redun_tags["redun.tags"]
+
+    redun_handle["redun.handle"]
+
+    redun_value -- "uses" --> redun_hashing
+
+    redun_file -- "extends" --> redun_value
+
+    redun_file -- "inherits from" --> redun_value
+
+    redun_file -- "uses" --> redun_hashing
+
+    redun_backends_db -- "implements" --> redun_backends_base
+
+    redun_backends_base -- "interacts with" --> redun_value
+
+    redun_backends_db -- "relies on" --> redun_value
+
+    redun_backends_value_store -- "leverages" --> redun_file
+
+    redun_backends_db -- "utilizes" --> redun_backends_value_store
+
+    redun_backends_db -- "manages" --> redun_tags
+
+    redun_handle -- "inherits from" --> redun_value
+
+    redun_backends_db -- "manages" --> redun_handle
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This component is fundamental to Redun's reproducibility, caching mechanisms, and historical analysis capabilities by managing the persistence, serialization, hashing, and retrieval of all workflow metadata, task values, and files.
+
+
+
+### redun.value
+
+This is the foundational module defining the `Value` base class, from which nearly all Redun data types (including expressions, tasks, files, and handles) inherit. It provides core mechanisms for consistent serialization, deserialization, and hashing of Python objects. The `TypeRegistry` within this module is crucial for managing how different data types are handled for persistence and caching.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/value.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.value` (1:1)</a>
+
+
+
+
+
+### redun.file
+
+This module extends the `redun.value` abstraction to specifically handle file and directory objects. It provides a unified interface for interacting with various file systems (e.g., local, S3, Azure Blob, GCP Storage, HTTP, FTP), abstracting away the underlying storage details. It ensures that files are treated as first-class Redun values, allowing them to be hashed, cached, and tracked within workflows.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/file.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.file` (1:1)</a>
+
+
+
+
+
+### redun.hashing
+
+This module provides the core logic for consistent hashing of Python objects and data structures. It is a cornerstone of Redun's caching mechanisms and reproducibility, ensuring that identical inputs always produce identical hashes, allowing for efficient cache lookups and verification of computational integrity.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/hashing.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.hashing` (1:1)</a>
+
+
+
+
+
+### redun.backends.base
+
+This module defines the abstract base classes and interfaces for Redun backends. It establishes the contract that any concrete backend implementation must adhere to for persisting and retrieving workflow metadata, job status, and cached results. It ensures a consistent API for different storage solutions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/backends/base.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.backends.base` (1:1)</a>
+
+
+
+
+
+### redun.backends.db
+
+This is a concrete implementation of `redun.backends.base`, providing a robust database-backed persistence layer for Redun. It handles the storage and retrieval of detailed workflow metadata, including executions, jobs, call nodes, values, and tags. It leverages internal serializers (`redun.backends.db.serializers`) to manage the structured storage of these entities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `redun.backends.db` (1:1)
+
+
+
+
+
+### redun.backends.value_store
+
+This component, often used in conjunction with `redun.backends.db`, is responsible for the efficient storage and retrieval of the actual content of large values (e.g., task outputs, intermediate data). It likely leverages file system abstractions provided by `redun.file` for its operations, separating large data storage from metadata.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/backends/value_store.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.backends.value_store` (1:1)</a>
+
+
+
+
+
+### redun.tags
+
+This module provides a mechanism for associating arbitrary key-value metadata (tags) with workflow entities such as executions and jobs. These tags are persisted by the backend and can be used for organization, filtering, and querying historical workflow data, enhancing the "historical analysis capabilities."
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/tags.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.tags` (1:1)</a>
+
+
+
+
+
+### redun.handle
+
+This module introduces the concept of "handles," which are `Value` objects that represent deferred or indirect access to other values. Handles are particularly useful for managing large or external data, allowing Redun to avoid unnecessary data movement until the value is actually needed, optimizing data flow.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/handle.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.handle` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Execution_Backends.md
+++ b/.codeboarding/Execution_Backends.md
@@ -1,0 +1,259 @@
+```mermaid
+
+graph LR
+
+    Executor["Executor"]
+
+    LocalExecutor["LocalExecutor"]
+
+    DockerExecutor["DockerExecutor"]
+
+    AWSBatchExecutor["AWSBatchExecutor"]
+
+    GCPBatchExecutor["GCPBatchExecutor"]
+
+    K8SExecutor["K8SExecutor"]
+
+    CommandUtils["CommandUtils"]
+
+    CodePackaging["CodePackaging"]
+
+    ScratchUtils["ScratchUtils"]
+
+    JobArrayer["JobArrayer"]
+
+    LocalExecutor -- "inherits from" --> Executor
+
+    LocalExecutor -- "uses" --> CommandUtils
+
+    LocalExecutor -- "uses" --> ScratchUtils
+
+    DockerExecutor -- "inherits from" --> Executor
+
+    DockerExecutor -- "uses" --> CommandUtils
+
+    DockerExecutor -- "uses" --> CodePackaging
+
+    AWSBatchExecutor -- "inherits from" --> Executor
+
+    AWSBatchExecutor -- "uses" --> DockerExecutor
+
+    AWSBatchExecutor -- "uses" --> JobArrayer
+
+    AWSBatchExecutor -- "uses" --> CodePackaging
+
+    GCPBatchExecutor -- "inherits from" --> Executor
+
+    GCPBatchExecutor -- "uses" --> DockerExecutor
+
+    GCPBatchExecutor -- "uses" --> JobArrayer
+
+    K8SExecutor -- "inherits from" --> Executor
+
+    K8SExecutor -- "uses" --> JobArrayer
+
+    K8SExecutor -- "uses" --> CodePackaging
+
+    DockerExecutor -- "uses" --> ScratchUtils
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Execution Backends` subsystem in `redun` provides an extensible and unified interface for executing tasks across diverse computational environments. It abstracts the complexities of running tasks locally, within Docker containers, or on various cloud-specific services, ensuring a consistent workflow regardless of the underlying infrastructure.
+
+
+
+### Executor
+
+This is the abstract base class for all executors in `redun`. It defines the common interface and lifecycle methods (e.g., `submit`, `submit_script`, `start`, `stop`, `monitor`) that all concrete executors must implement or override. It provides a foundational structure for managing job submissions, monitoring, and result processing, ensuring consistency across different execution environments.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/executors/base.py#L12-L73" target="_blank" rel="noopener noreferrer">`redun.executors.base.Executor` (12:73)</a>
+
+
+
+
+
+### LocalExecutor
+
+The simplest concrete implementation of `Executor`, designed for running tasks directly on the local machine where `redun` is invoked. It's primarily used for development, testing, and small-scale workflows, serving as the default execution backend.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/executors/local.py#L64-L261" target="_blank" rel="noopener noreferrer">`redun.executors.local.LocalExecutor` (64:261)</a>
+
+
+
+
+
+### DockerExecutor
+
+An executor that runs tasks within Docker containers. It handles Docker image management and container execution, serving as a crucial component for isolated and reproducible task execution. It can also act as a base for other container-orchestrated executors.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/executors/docker.py#L250-L478" target="_blank" rel="noopener noreferrer">`redun.executors.docker.DockerExecutor` (250:478)</a>
+
+
+
+
+
+### AWSBatchExecutor
+
+A concrete implementation of `Executor` that leverages AWS Batch for executing tasks. It handles the specifics of interacting with AWS Batch services, including creating and managing job definitions, submitting jobs, and monitoring their status, integrating with AWS ECR and S3.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/executors/aws_batch.py#L832-L1490" target="_blank" rel="noopener noreferrer">`redun.executors.aws_batch.AWSBatchExecutor` (832:1490)</a>
+
+
+
+
+
+### GCPBatchExecutor
+
+Implements task execution on Google Cloud Platform's Batch service. Similar to `AWSBatchExecutor`, it manages GCP Batch jobs, handles resource allocation, and monitors job progress, often using `DockerExecutor` internally.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/executors/gcp_batch.py#L47-L614" target="_blank" rel="noopener noreferrer">`redun.executors.gcp_batch.GCPBatchExecutor` (47:614)</a>
+
+
+
+
+
+### K8SExecutor
+
+This executor integrates with Kubernetes clusters to run tasks as Kubernetes Jobs. It manages Kubernetes resources (Jobs, Pods, Secrets) and handles the complexities of deploying and monitoring containerized tasks within a Kubernetes environment.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/executors/k8s.py#L358-L1118" target="_blank" rel="noopener noreferrer">`redun.executors.k8s.K8SExecutor` (358:1118)</a>
+
+
+
+
+
+### CommandUtils
+
+A utility module for generating shell commands that execute `redun` tasks within the job environment. This is a fundamental component as all concrete executors rely on it to construct the actual commands that will be run.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/executors/command.py#L0-L0" target="_blank" rel="noopener noreferrer">`redun.executors.command` (0:0)</a>
+
+
+
+
+
+### CodePackaging
+
+A utility module responsible for packaging the necessary `redun` code and user scripts into deployable artifacts (e.g., zip files, Docker images). This is crucial for remote executors to have access to the workflow code.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/executors/code_packaging.py#L0-L0" target="_blank" rel="noopener noreferrer">`redun.executors.code_packaging` (0:0)</a>
+
+
+
+
+
+### ScratchUtils
+
+A utility module for managing temporary files, storing job results, and handling error logs in a designated scratch space accessible by the executors. It ensures proper handling of intermediate and output data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/executors/scratch.py#L0-L0" target="_blank" rel="noopener noreferrer">`redun.executors.scratch` (0:0)</a>
+
+
+
+
+
+### JobArrayer
+
+A utility for handling job arrays, allowing a single job submission to represent multiple, similar tasks. This is particularly useful for optimizing and scaling batch processing on cloud platforms by reducing overhead.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/job_array.py#L0-L0" target="_blank" rel="noopener noreferrer">`redun.job_array` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/User_Interface.md
+++ b/.codeboarding/User_Interface.md
@@ -1,0 +1,181 @@
+```mermaid
+
+graph LR
+
+    Redun_CLI_Client["Redun CLI Client"]
+
+    CLI_Utilities["CLI Utilities"]
+
+    Redun_Console_Application["Redun Console Application"]
+
+    Console_Screens["Console Screens"]
+
+    Console_Widgets["Console Widgets"]
+
+    Call_Graph_Query["Call Graph Query"]
+
+    Redun_CLI_Client -- "Interacts with" --> Scheduler
+
+    Redun_CLI_Client -- "Configures" --> Config
+
+    Redun_CLI_Client -- "Utilizes" --> CLI_Utilities
+
+    Redun_CLI_Client -- "Accesses" --> Redun_Backend_DB
+
+    Redun_Console_Application -- "Manages" --> Console_Screens
+
+    Redun_Console_Application -- "Monitors" --> Scheduler
+
+    Redun_Console_Application -- "Queries" --> Call_Graph_Query
+
+    Console_Screens -- "Composes" --> Console_Widgets
+
+    Console_Screens -- "Fetches data from" --> Call_Graph_Query
+
+    Call_Graph_Query -- "Retrieves data from" --> Redun_Backend_DB
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+These components are fundamental because they directly implement the user-facing aspects of Redun, providing the means for users to interact with and monitor their workflows.
+
+
+
+*   **Redun CLI Client** and **CLI Utilities**: These form the backbone of the command-line interface, which is the primary way users initiate and manage Redun workflows. They are essential for direct, scriptable interaction with the Redun system.
+
+*   **Redun Console Application**, **Console Screens**, and **Console Widgets**: These three components collectively provide the interactive, real-time monitoring and inspection capabilities of Redun's Text-based User Interface (TUI). The `Redun Console Application` orchestrates the TUI, `Console Screens` define the distinct views for different types of workflow data, and `Console Widgets` are the reusable building blocks that compose these screens. This TUI is crucial for understanding complex workflow executions and debugging.
+
+*   **Call Graph Query**: This component acts as the essential data access layer for the TUI. It abstracts the underlying database structure and provides a structured way for the console to retrieve and display relevant workflow information, making the interactive experience possible.
+
+
+
+These components are distinct in their responsibilities (CLI vs. TUI, UI structure vs. data access) but work together to provide a comprehensive user interface for Redun. The `Scheduler` and `Redun Backend DB` are considered external dependencies that the User Interface interacts with, rather than being part of the User Interface subsystem itself.
+
+
+
+### Redun CLI Client
+
+The primary command-line interface (CLI) client for Redun, implemented by `redun.cli.RedunClient`. It serves as the main entry point for users to execute various Redun commands, such as running tasks, managing configurations, and interacting with the backend.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/cli.py#L864-L3192" target="_blank" rel="noopener noreferrer">`redun.cli.RedunClient` (864:3192)</a>
+
+
+
+
+
+### CLI Utilities
+
+A collection of helper functions and classes within the `redun.cli` module that support the `Redun CLI Client`. These utilities handle common CLI-related tasks like argument parsing, configuration management, version checking, and output formatting.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/cli.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.cli` (1:1)</a>
+
+
+
+
+
+### Redun Console Application
+
+The main application class for the interactive Redun console (TUI), implemented by `redun.console.app.RedunApp`. It manages the overall console's lifecycle, handles screen navigation, and serves as the central hub for the graphical user interface.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/console/app.py#L69-L239" target="_blank" rel="noopener noreferrer">`redun.console.app.RedunApp` (69:239)</a>
+
+
+
+
+
+### Console Screens
+
+A set of classes, inheriting from `redun.console.screens.RedunScreen`, that define the various interactive views within the Redun console (e.g., `ExecutionScreen`, `SearchScreen`, `ReplScreen`). Each screen is responsible for displaying specific types of workflow data, handling user input, and managing its own state.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/console/screens.py#L57-L133" target="_blank" rel="noopener noreferrer">`redun.console.screens.RedunScreen` (57:133)</a>
+
+- <a href="https://github.com/insitro/redun/redun/console/screens.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.console.screens` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/console/upstream_screen.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.console.upstream_screen` (1:1)</a>
+
+
+
+
+
+### Console Widgets
+
+Reusable UI components (e.g., `Table`, `CommandInput`, `ExecutionList`, `JobList`, `RedunHeader`) defined in `redun.console.widgets`. These modular elements are used by Console Screens to display data, receive input, and enhance the user experience within the TUI.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/console/widgets.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.console.widgets` (1:1)</a>
+
+
+
+
+
+### Call Graph Query
+
+A component, primarily `redun.backends.db.query.CallGraphQuery`, responsible for querying and retrieving structured workflow data (e.g., executions, jobs, tasks, values) from the Redun backend database. It provides the necessary data for the interactive console screens.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/backends/db/query.py#L148-L777" target="_blank" rel="noopener noreferrer">`redun.backends.db.query.CallGraphQuery` (148:777)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Workflow_Orchestrator.md
+++ b/.codeboarding/Workflow_Orchestrator.md
@@ -1,0 +1,323 @@
+```mermaid
+
+graph LR
+
+    Workflow_Orchestrator["Workflow Orchestrator"]
+
+    Scheduler["Scheduler"]
+
+    Task_Definition["Task Definition"]
+
+    Expression_Handling["Expression Handling"]
+
+    Promise_Management["Promise Management"]
+
+    RedunBackendDb["RedunBackendDb"]
+
+    Executors["Executors"]
+
+    Config["Config"]
+
+    File_System["File System"]
+
+    RedunClient["RedunClient"]
+
+    Workflow_Orchestrator -- "Composes" --> Scheduler
+
+    Workflow_Orchestrator -- "Composes" --> Task_Definition
+
+    Workflow_Orchestrator -- "Composes" --> Expression_Handling
+
+    Workflow_Orchestrator -- "Composes" --> Promise_Management
+
+    Workflow_Orchestrator -- "Persists state to" --> RedunBackendDb
+
+    Workflow_Orchestrator -- "Delegates task execution to" --> Executors
+
+    Workflow_Orchestrator -- "Is configured by" --> Config
+
+    Workflow_Orchestrator -- "Interacts with" --> File_System
+
+    Workflow_Orchestrator -- "Initiated and monitored by" --> RedunClient
+
+    Scheduler -- "Part of" --> Workflow_Orchestrator
+
+    Scheduler -- "Orchestrates" --> Task_Definition
+
+    Scheduler -- "Processes" --> Expression_Handling
+
+    Scheduler -- "Manages" --> Promise_Management
+
+    Scheduler -- "Persists state to" --> RedunBackendDb
+
+    Scheduler -- "Delegates execution to" --> Executors
+
+    Scheduler -- "Is configured by" --> Config
+
+    Scheduler -- "Interacts with" --> File_System
+
+    Task_Definition -- "Part of" --> Workflow_Orchestrator
+
+    Task_Definition -- "Managed by" --> Scheduler
+
+    Task_Definition -- "Can be represented as" --> Expression_Handling
+
+    Expression_Handling -- "Part of" --> Workflow_Orchestrator
+
+    Expression_Handling -- "Processed by" --> Scheduler
+
+    Expression_Handling -- "Involves" --> Task_Definition
+
+    Promise_Management -- "Part of" --> Workflow_Orchestrator
+
+    Promise_Management -- "Used by" --> Scheduler
+
+    Promise_Management -- "Related to" --> Task_Definition
+
+    RedunBackendDb -- "Persists state for" --> Workflow_Orchestrator
+
+    RedunBackendDb -- "Persists state for" --> Scheduler
+
+    RedunBackendDb -- "Accessed by" --> RedunClient
+
+    Executors -- "Used by" --> Scheduler
+
+    Executors -- "Interacts with" --> File_System
+
+    Executors -- "Configured by" --> Config
+
+    Config -- "Configures" --> Workflow_Orchestrator
+
+    Config -- "Configures" --> Scheduler
+
+    Config -- "Configures" --> Executors
+
+    Config -- "Accessed by" --> RedunClient
+
+    File_System -- "Used by" --> Workflow_Orchestrator
+
+    File_System -- "Used by" --> Scheduler
+
+    File_System -- "Used by" --> Executors
+
+    File_System -- "Used by" --> RedunClient
+
+    RedunClient -- "Initiates and monitors" --> Workflow_Orchestrator
+
+    RedunClient -- "Accesses workflow state for logging and visualization" --> Scheduler
+
+    RedunClient -- "Initializes and retrieves system configurations" --> Config
+
+    RedunClient -- "Performs database-specific operations" --> RedunBackendDb
+
+    RedunClient -- "Reads and writes workflow-related files" --> File_System
+
+    click Workflow_Orchestrator href "https://github.com/insitro/redun/blob/main/.codeboarding//Workflow_Orchestrator.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Detailed analysis of the Redun workflow orchestration system, outlining its key components and their interdependencies.
+
+
+
+### Workflow Orchestrator [[Expand]](./Workflow_Orchestrator.md)
+
+The core intelligence of Redun, responsible for defining, scheduling, and managing the execution of tasks within a computational graph. It handles dependency resolution, caching logic, and asynchronous operations, acting as the central coordinator for workflow execution. This component is fundamentally composed of the Scheduler, Task Definition, Expression Handling, and Promise Management components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/scheduler.py#L881-L2298" target="_blank" rel="noopener noreferrer">`redun.scheduler.Scheduler` (881:2298)</a>
+
+- <a href="https://github.com/insitro/redun/redun/task.py#L141-L564" target="_blank" rel="noopener noreferrer">`redun.task.Task` (141:564)</a>
+
+- <a href="https://github.com/insitro/redun/redun/expression.py#L38-L111" target="_blank" rel="noopener noreferrer">`redun.expression.Expression` (38:111)</a>
+
+- <a href="https://github.com/insitro/redun/redun/promise.py#L6-L187" target="_blank" rel="noopener noreferrer">`redun.promise.Promise` (6:187)</a>
+
+
+
+
+
+### Scheduler
+
+The core engine within the Workflow Orchestrator, specifically responsible for managing the execution of tasks, tracking job states, resolving dependencies, and interacting with various executors. It maintains the overall state of active and historical workflows.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/scheduler.py#L881-L2298" target="_blank" rel="noopener noreferrer">`redun.scheduler.Scheduler` (881:2298)</a>
+
+
+
+
+
+### Task Definition
+
+Defines the atomic units of work within a Redun workflow. Tasks encapsulate Python functions and their associated metadata, allowing them to be tracked, cached, and executed within the computational graph.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/task.py#L141-L564" target="_blank" rel="noopener noreferrer">`redun.task.Task` (141:564)</a>
+
+
+
+
+
+### Expression Handling
+
+Manages the representation and evaluation of the computational graph. Expressions define how tasks and values are combined and depend on each other, forming the basis for dependency resolution and execution planning.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/expression.py#L38-L111" target="_blank" rel="noopener noreferrer">`redun.expression.Expression` (38:111)</a>
+
+
+
+
+
+### Promise Management
+
+Provides a mechanism for handling asynchronous results and deferred computations within the workflow. Promises allow the scheduler to manage dependencies efficiently, enabling parallel execution and proper sequencing of tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/promise.py#L6-L187" target="_blank" rel="noopener noreferrer">`redun.promise.Promise` (6:187)</a>
+
+
+
+
+
+### RedunBackendDb
+
+The database backend component responsible for persisting Redun's workflow metadata, task results, execution logs, and other internal states. It provides an interface for storing and retrieving this critical information.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `redun.backends.db.RedunBackendDb` (1:1)
+
+
+
+
+
+### Executors
+
+A set of components responsible for executing Redun tasks in various environments (e.g., local, AWS Batch, Docker, Kubernetes). Each executor provides an interface for running tasks and managing their lifecycle within its specific execution context.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/executors/base.py#L12-L73" target="_blank" rel="noopener noreferrer">`redun.executors.base.Executor` (12:73)</a>
+
+
+
+
+
+### Config
+
+Manages the configuration settings for the entire Redun system. This includes database connection details, executor configurations, and other global parameters that influence Redun's behavior.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/config.py#L38-L150" target="_blank" rel="noopener noreferrer">`redun.config.Config` (38:150)</a>
+
+
+
+
+
+### File System
+
+An abstraction layer for handling file operations across different storage systems (e.g., local disk, AWS S3, Google Cloud Storage, Azure Blob Storage). It ensures that Redun can seamlessly interact with various data sources and sinks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/file.py#L210-L397" target="_blank" rel="noopener noreferrer">`redun.file.FileSystem` (210:397)</a>
+
+
+
+
+
+### RedunClient
+
+The primary command-line interface (CLI) client for Redun. It acts as the main entry point for users to execute various Redun commands, such as running tasks, managing configurations, inspecting workflow history, and interacting with the backend.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/cli.py#L864-L3192" target="_blank" rel="noopener noreferrer">`redun.cli.RedunClient` (864:3192)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,185 @@
+```mermaid
+
+graph LR
+
+    Workflow_Orchestrator["Workflow Orchestrator"]
+
+    Data_State_Management["Data & State Management"]
+
+    Execution_Backends["Execution Backends"]
+
+    User_Interface["User Interface"]
+
+    System_Configuration["System Configuration"]
+
+    Workflow_Orchestrator -- "Delegates to" --> Execution_Backends
+
+    Workflow_Orchestrator -- "Interacts with" --> Data_State_Management
+
+    Data_State_Management -- "Provides services to" --> Workflow_Orchestrator
+
+    Data_State_Management -- "Used by" --> Execution_Backends
+
+    Execution_Backends -- "Receives tasks from" --> Workflow_Orchestrator
+
+    Execution_Backends -- "Utilizes" --> Data_State_Management
+
+    User_Interface -- "Initiates actions in" --> Workflow_Orchestrator
+
+    User_Interface -- "Queries" --> Data_State_Management
+
+    System_Configuration -- "Provides settings to" --> Workflow_Orchestrator
+
+    System_Configuration -- "Provides settings to" --> Execution_Backends
+
+    click Workflow_Orchestrator href "https://github.com/insitro/redun/blob/main/.codeboarding//Workflow_Orchestrator.md" "Details"
+
+    click Data_State_Management href "https://github.com/insitro/redun/blob/main/.codeboarding//Data_State_Management.md" "Details"
+
+    click Execution_Backends href "https://github.com/insitro/redun/blob/main/.codeboarding//Execution_Backends.md" "Details"
+
+    click User_Interface href "https://github.com/insitro/redun/blob/main/.codeboarding//User_Interface.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Final Architecture Overview for `redun`
+
+
+
+### Workflow Orchestrator [[Expand]](./Workflow_Orchestrator.md)
+
+The core intelligence of Redun, responsible for defining, scheduling, and managing the execution of tasks within a computational graph. It handles dependency resolution, caching logic, and asynchronous operations, acting as the central coordinator for workflow execution.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/scheduler.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.scheduler` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/task.py#L718-L720" target="_blank" rel="noopener noreferrer">`redun.task` (718:720)</a>
+
+- <a href="https://github.com/insitro/redun/redun/expression.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.expression` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/promise.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.promise` (1:1)</a>
+
+
+
+
+
+### Data & State Management [[Expand]](./Data_State_Management.md)
+
+Manages the persistence, serialization, hashing, and retrieval of all workflow metadata, task values, and files. This component is fundamental to Redun's reproducibility, caching mechanisms, and historical analysis capabilities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `redun.backends.db` (1:1)
+
+- <a href="https://github.com/insitro/redun/redun/value.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.value` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/file.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.file` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/hashing.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.hashing` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/tags.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.tags` (1:1)</a>
+
+
+
+
+
+### Execution Backends [[Expand]](./Execution_Backends.md)
+
+An extensible layer that abstracts the execution of tasks across various computational environments. It provides a unified interface for running tasks locally, in Docker containers, or on cloud-specific services like AWS Batch, GCP Batch, or Kubernetes.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/executors/base.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.executors.base` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/executors/local.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.executors.local` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/executors/docker.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.executors.docker` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/executors/aws_batch.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.executors.aws_batch` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/executors/aws_glue.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.executors.aws_glue` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/executors/gcp_batch.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.executors.gcp_batch` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/executors/k8s.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.executors.k8s` (1:1)</a>
+
+
+
+
+
+### User Interface [[Expand]](./User_Interface.md)
+
+Provides the primary means for users to interact with Redun. This includes the command-line interface (CLI) for initiating and managing workflows, and an interactive console (TUI) for monitoring and inspecting execution history.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/cli.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.cli` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/console/app.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.console.app` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/console/screens.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.console.screens` (1:1)</a>
+
+- <a href="https://github.com/insitro/redun/redun/console/widgets.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.console.widgets` (1:1)</a>
+
+
+
+
+
+### System Configuration
+
+Centralized management of Redun's operational settings. It allows users to customize various aspects of the system, including executor parameters, database connections, and default behaviors, ensuring flexible deployment and operation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/insitro/redun/redun/config.py#L1-L1" target="_blank" rel="noopener noreferrer">`redun.config` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR adds an architectural diagram of the redun codebase, generated through static analysis and LLM-based tools. You can preview how it renders here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/redun/on_boarding.md

The goal is to give new contributors a fast, intuitive overview of the project's structure and how its core components interact. Since redun already makes great use of diagrams I think that you'd like this approach. Let me know where do you stand on diagram first documentation!

Any feedback is more than welcome!

If it’s helpful, I’d be happy to integrate our free GitHub Action to keep it updated in your Sphinx docs.

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.